### PR TITLE
Support HTTP headers

### DIFF
--- a/spec/form-spec.coffee
+++ b/spec/form-spec.coffee
@@ -11,6 +11,9 @@ describe 'Outbound Form POST request', ->
       form_field:
         fname: 'Mel'
         lname: 'Gibson'
+      header:
+        Whatever: 'foo'
+        Bar: 'baz'
 
     assert.equal integration.request(vars).url, 'http://foo.bar'
     assert.equal integration.request(vars).method, 'POST'
@@ -19,6 +22,8 @@ describe 'Outbound Form POST request', ->
       'Content-Type': 'application/x-www-form-urlencoded'
       'Content-Length': 22
       'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;0.6,text/plain;q=0.5'
+      'Whatever': 'foo'
+      'Bar': 'baz'
 
 
   it 'should support simple dot-notation', ->
@@ -91,3 +96,15 @@ describe 'Outbound Form POST validation', ->
 
   it 'should pass validation', ->
     assert.isUndefined integration.validate(url: 'http://foo')
+
+
+  it 'should not allow content-type header', ->
+    assert.equal integration.validate(url: 'http://foo', header: { 'Content-Type': 'foo' }), 'Content-Type header is not allowed'
+
+
+  it 'should not allow content-length header', ->
+    assert.equal integration.validate(url: 'http://foo', header: { 'Content-Length': '10' }), 'Content-Length header is not allowed'
+
+
+  it 'should not allow accept header', ->
+    assert.equal integration.validate(url: 'http://foo', header: { 'Accept': 'text/whatever' }), 'Accept header is not allowed'

--- a/spec/headers-spec.coffee
+++ b/spec/headers-spec.coffee
@@ -1,0 +1,22 @@
+assert = require('chai').assert
+headers = require('../src/headers')
+types = require('leadconduit-types')
+
+
+describe 'Headers', ->
+
+  it 'should remove header with empty value', ->
+    assert.deepEqual headers(Foo: 'bar', Baz: ''), Foo: 'bar'
+
+
+  it 'should remove header with whitespace value', ->
+    assert.deepEqual headers(Foo: 'bar', Baz: ' '), Foo: 'bar'
+
+
+  it 'should join header with array value', ->
+    assert.deepEqual headers(Foo: ['bar', 'baz'],), Foo: 'bar, baz'
+
+
+  it 'should normalize header with richly typed value', ->
+    assert.deepEqual headers(Foo: types.number.parse('10')), Foo: '10'
+    assert.deepEqual headers(Foo: types.phone.parse('512-789-1111')), Foo: '5127891111'

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -11,6 +11,9 @@ describe 'Outbound JSON request', ->
       json_property:
         fname: 'Mel'
         lname: 'Gibson'
+      header:
+        Whatever: 'foo'
+        Bar: 'baz'
 
     assert.equal integration.request(vars).url, 'http://foo.bar'
     assert.equal integration.request(vars).method, 'POST'
@@ -19,6 +22,8 @@ describe 'Outbound JSON request', ->
       'Content-Type': 'application/json'
       'Content-Length': 32
       'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;0.6,text/plain;q=0.5'
+      'Whatever': 'foo'
+      'Bar': 'baz'
 
 
   it 'should support simple dot-notation', ->
@@ -101,3 +106,14 @@ describe 'JSON validation', ->
   it 'should pass validation', ->
     assert.isUndefined integration.validate(url: 'http://foo')
 
+
+  it 'should not allow content-type header', ->
+    assert.equal integration.validate(url: 'http://foo', header: { 'Content-Type': 'foo' }), 'Content-Type header is not allowed'
+
+
+  it 'should not allow content-length header', ->
+    assert.equal integration.validate(url: 'http://foo', header: { 'Content-Length': '10' }), 'Content-Length header is not allowed'
+
+
+  it 'should not allow accept header', ->
+    assert.equal integration.validate(url: 'http://foo', header: { 'Accept': 'text/whatever' }), 'Accept header is not allowed'

--- a/src/form.coffee
+++ b/src/form.coffee
@@ -5,6 +5,7 @@ response = require('./response')
 validate = require('./validate')
 normalize = require('./normalize')
 variables = require('./variables')
+headers = require('./headers')
 
 
 
@@ -25,7 +26,7 @@ request = (vars) ->
 
   url: vars.url
   method: 'POST'
-  headers:
+  headers: _.merge headers(vars.header),
     'Content-Type': 'application/x-www-form-urlencoded'
     'Content-Length': body.length
     'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;0.6,text/plain;q=0.5'
@@ -39,7 +40,7 @@ request = (vars) ->
 request.variables = ->
   [
     { name: 'url', description: 'Server URL', type: 'string', required: true }
-    { name: 'form_field.*', type: 'wildcard', required: false }
+    { name: 'form_field.*', description: 'Form field name', type: 'wildcard', required: false }
   ].concat(variables)
 
 
@@ -52,4 +53,4 @@ module.exports =
   request: request
   response: response
   validate: (vars) ->
-    validate.url(vars) ? validate.outcome(vars)
+    validate.url(vars) ? validate.outcome(vars) ? validate.headers(vars)

--- a/src/headers.coffee
+++ b/src/headers.coffee
@@ -1,0 +1,18 @@
+_ = require('lodash')
+normalize = require('./normalize')
+
+
+module.exports = (header) ->
+  return {} unless _.isPlainObject(header)
+
+  _(normalize(header))
+    .mapValues (v) ->
+      if _.isArray(v)
+        v.join(', ')
+      else if _.isPlainObject(v)
+        ''
+      else
+        v.toString()
+    .omitBy (v, k) ->
+      !v?.trim() or !k?.trim()
+    .value()

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -4,6 +4,7 @@ response = require('./response')
 validate = require('./validate')
 normalize = require('./normalize')
 variables = require('./variables')
+headers = require('./headers')
 
 
 
@@ -16,7 +17,7 @@ request = (vars) ->
 
   url: vars.url
   method: vars.method?.toUpperCase() ? 'POST'
-  headers:
+  headers: _.merge headers(vars.header),
     'Content-Type': 'application/json'
     'Content-Length': body.length
     'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;0.6,text/plain;q=0.5'
@@ -32,7 +33,7 @@ request.variables = ->
   [
     { name: 'url', description: 'Server URL', type: 'string', required: true }
     { name: 'method', description: 'HTTP method (POST, PUT, or DELETE)', type: 'string', required: true }
-    { name: 'json_property.*', type: 'wildcard', required: false }
+    { name: 'json_property.*', description: 'JSON property in dot notation', type: 'wildcard', required: false }
   ].concat(variables)
 
 
@@ -46,5 +47,8 @@ module.exports =
   request: request
   response: response
   validate: (vars) ->
-    validate.url(vars) ? validate.method(vars, ['POST', 'PUT', 'DELETE']) ? validate.outcome(vars)
+    validate.url(vars) ?
+      validate.method(vars, ['POST', 'PUT', 'DELETE']) ?
+      validate.outcome(vars) ?
+      validate.headers(vars)
 

--- a/src/validate.coffee
+++ b/src/validate.coffee
@@ -1,3 +1,4 @@
+_ = require('lodash')
 u = require('url')
 
 isValidUrl = (url) ->
@@ -31,6 +32,17 @@ module.exports =
 
     unless vars.outcome_on_match == 'success' or vars.outcome_on_match == 'failure'
       "Outcome on match must be 'success' or 'failure'"
+
+
+  headers: (vars) ->
+    return unless _.isPlainObject(vars.header)
+
+    headers = _.mapKeys vars.header, (v, k) ->
+        k.toLowerCase()
+
+    for disallowedHeader in ['Content-Type', 'Content-Length', 'Accept']
+      return "#{disallowedHeader} header is not allowed" if headers[disallowedHeader.toLowerCase()]
+
 
 
 

--- a/src/variables.coffee
+++ b/src/variables.coffee
@@ -4,4 +4,5 @@ module.exports = [
   { name: 'outcome_on_match', description: 'The outcome when the term is found - "success" or "failure" (default: success)', type: 'string', required: true }
   { name: 'reason_path', description: 'The dot-notation path, XPath location, or regular expression with a single capture group, used to find the failure reason', type: 'string', required: false }
   { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false }
+  { name: 'header.*', description: 'HTTP header to send in the request', type: 'wildcard', required: false }
 ]


### PR DESCRIPTION
HTTP request headers can now be mapped.

![screen shot 2016-02-12 at 3 07 15 pm](https://cloud.githubusercontent.com/assets/569/13020315/5614388c-d19a-11e5-8f5f-0f2939b56f47.png)